### PR TITLE
Removed "config" dir from .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -7,4 +7,3 @@
 __pycache__
 .pytest_cache
 tmp/
-config/


### PR DESCRIPTION
Hi!

Thanks for those tests, it's really helpful!
I was trying to create the container image and it wouldn't work. After some head scratching, I noticed that the "config" dir wasn't part of the image due to it being present in the ".dockerignore" file.

If you agree that it should be part of it, here's a pull request to restore it :-)