### PR TITLE
Install gcc before installing pip packages, then remove it

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,13 @@ COPY . /app/
 WORKDIR /app
 
 # Install requirements
-RUN pip install --no-cache-dir -r requirements.txt
+ARG DEBIAN_FRONTEND=noninteractive
+RUN apt-get update \
+    && apt-get install -y gcc \
+    && pip install --no-cache-dir -r requirements.txt \
+    && apt-get remove -y gcc \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
 
 # Your application's default run command
 CMD ["pytest"]


### PR DESCRIPTION
Closes #2 

This change installs the `gcc` package before installing the `pip` requirements, and then uninstalls the package after the `pip` packages have been compiled. It also performs the necessary `apt` housekeeping to keep image size small.